### PR TITLE
update component stauts and hub progress

### DIFF
--- a/pkg/openapi/cluster/usecase/component_usecase.go
+++ b/pkg/openapi/cluster/usecase/component_usecase.go
@@ -123,6 +123,8 @@ func (cc *ComponentUsecaseImpl) typeRbdComponentStatus(cpn *rainbondv1alpha1.Rbd
 
 	for index, _ := range status.PodStatuses {
 		if status.PodStatuses[index].Phase == "NotReady" {
+			status.Status = v1.ComponentStatusCreating // if pod not ready, component status can't be running, even nor replicas equals to ready replicas
+			// message and reason from container
 			for _, container := range status.PodStatuses[index].ContainerStatuses {
 				if container.State != "Running" {
 					status.PodStatuses[index].Message = container.Message

--- a/pkg/openapi/cluster/usecase/install_usecase.go
+++ b/pkg/openapi/cluster/usecase/install_usecase.go
@@ -2,8 +2,9 @@ package usecase
 
 import (
 	"fmt"
-	"github.com/goodrain/rainbond-operator/pkg/generated/clientset/versioned"
 	"time"
+
+	"github.com/goodrain/rainbond-operator/pkg/generated/clientset/versioned"
 
 	v1 "github.com/goodrain/rainbond-operator/pkg/openapi/types/v1"
 
@@ -264,6 +265,12 @@ func (ic *InstallUseCaseImpl) stepHub(clusterInfo *v1alpha1.RainbondCluster, com
 		if cs.ISInitComponent {
 			initComponents = append(initComponents, cs)
 		}
+	}
+
+	if len(initComponents) == 0 {
+		// component not ready
+		status.Status = InstallStatusWaiting
+		return status
 	}
 
 	readyCount := 0


### PR DESCRIPTION
1、组件存在实例NotReady的情况则认为是创建中状态
2、如果初始化组件列表为0， 则认为安装镜像仓库步骤为等待中（如果不需要安装默认镜像仓库则rainbondCluster.Spec.ImageHub不会为空，则任务安装镜像仓库进度直接为100%）