### PR TITLE
fix enterprise id bugs

### DIFF
--- a/pkg/openapi/cluster/usecase/cluster_ucase.go
+++ b/pkg/openapi/cluster/usecase/cluster_ucase.go
@@ -385,6 +385,7 @@ func (c *clusterUsecase) createCluster() (*rainbondv1alpha1.RainbondCluster, err
 
 	annotations := make(map[string]string)
 	annotations["install_id"] = uuidutil.NewUUID()
+	annotations["enterprise_id"] = c.repo.EnterpriseID()
 	cluster.Annotations = annotations
 
 	return c.cfg.RainbondKubeClient.RainbondV1alpha1().RainbondClusters(c.cfg.Namespace).Create(cluster)


### PR DESCRIPTION
初始化集群时将enterpriseID写到rainbondCluster的annotation中
enterpriseID默认从/opt/rainbond/.init/enterprise文件中获取，没有则重新生成，并持久化到该路径