### PR TITLE
Support for arm64 Compilation and Support for arm64 Etcd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
 FROM golang:1.15 as builder
-
+ARG ARCH=amd64
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -17,7 +17,7 @@ COPY controllers/ controllers/
 COPY util util/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="${ARCH}" GO111MODULE=on go build -a -o manager main.go
 
 
 FROM alpine:3.11.2

--- a/controllers/handler/etcd.go
+++ b/controllers/handler/etcd.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/goodrain/rainbond-operator/util/k8sutil"
@@ -112,6 +113,12 @@ func (e *etcd) statefulsetForEtcd() client.Object {
 			Name:  "ETCD_QUOTA_BACKEND_BYTES",
 			Value: "4294967296", // 4 Gi
 		},
+	}
+	if runtime.GOARCH == "arm64" {
+		env = append(env, corev1.EnvVar{
+			Name:  "ETCD_UNSUPPORTED_ARCH",
+			Value: "arm64",
+		})
 	}
 	env = mergeEnvs(env, e.component.Spec.Env)
 


### PR DESCRIPTION
Compilation command
```
docker build --build-arg ARCH=arm64 -t domain/namespace/rainbond-operator:v2.2.0-arm .
```