### PR TITLE
fix: ipv6 address prevents api secret from being created

### DIFF
--- a/controllers/rainbondcluster_controller.go
+++ b/controllers/rainbondcluster_controller.go
@@ -321,6 +321,10 @@ func (r *RainbondClusterReconciler) GetRainbondGatewayNodeAndChaosNodes() (gatew
 func getK8sNode(node corev1.Node) *rainbondv1alpha1.K8sNode {
 	var Knode rainbondv1alpha1.K8sNode
 	for _, address := range node.Status.Addresses {
+		// skip ipv6
+		if len(net.ParseIP(address.Address)) == net.IPv6len {
+			continue
+		}
 		if address.Type == corev1.NodeInternalIP {
 			Knode.InternalIP = address.Address
 		}


### PR DESCRIPTION
问题：当在具有ipv6的环境下使用helm部署时，如果未指定网关节点ip、构建节点ip以及外部访问ip时，operator 会自动选择 ip，并且将 ip 作为 label 存储在 api 证书 secret 的 label 中，但是 label 不支持 ipv6 这种形式的字符串存储，会导致 secret 无法创建，从而阻碍 api 的创建。

解决方案：当前暂不支持 ipv6 地址的选择。