### PR TITLE
feat: generate stable EID and MySQL password based on cluster identity

### DIFF
--- a/config/prom/prometheus.yml
+++ b/config/prom/prometheus.yml
@@ -140,3 +140,17 @@ scrape_configs:
       - targets: ['kube-state-metrics.rbd-plugins.svc.cluster.local:8080']
         labels:
           component: kube-state-metrics
+  - job_name: hami-scheduler
+    honor_labels: true
+    scrape_interval: 5s
+    scrape_timeout: 3s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['hami-scheduler.rbd-plugins.svc.cluster.local:31993']
+  - job_name: dcgm-exporter
+    honor_labels: true
+    scrape_interval: 5s
+    scrape_timeout: 3s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['dcgm-exporter.rbd-plugins.svc.cluster.local:9400']

--- a/controllers/handler/apigateway.go
+++ b/controllers/handler/apigateway.go
@@ -507,16 +507,13 @@ plugins: # plugin list (sorted by priority)
   - ext-plugin-post-req            # priority: -3000
   - ext-plugin-post-resp           # priority: -4000
 `
-	// 将 tab 替换为空格，确保 YAML 格式正确
-	configYaml = strings.ReplaceAll(configYaml, "\t", "  ")
-
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "apisix-gw-config.yaml",
 			Namespace: rbdutil.GetenvDefault("RBD_NAMESPACE", constants.Namespace),
 		},
 		Data: map[string]string{
-			"config.yaml": configYaml,
+			"config.yaml": FormatYAMLConfig(configYaml),
 		},
 	}
 }

--- a/controllers/handler/common.go
+++ b/controllers/handler/common.go
@@ -464,3 +464,8 @@ func createIngressMeta(name, namespace string, annotations, labels map[string]st
 		Labels:      labels,
 	}
 }
+
+// FormatYAMLConfig 将 YAML 配置中的 tab 替换为空格，确保 YAML 格式正确
+func FormatYAMLConfig(config string) string {
+	return strings.ReplaceAll(config, "\t", "  ")
+}

--- a/controllers/handler/monitor.go
+++ b/controllers/handler/monitor.go
@@ -232,8 +232,8 @@ func (m *monitor) configmap() client.Object {
 			Namespace: rbdutil.GetenvDefault("RBD_NAMESPACE", constants.Namespace),
 		},
 		Data: map[string]string{
-			"prometheus.yml": string(prometheus),
-			"rules.yml":      string(rules),
+			"prometheus.yml": FormatYAMLConfig(string(prometheus)),
+			"rules.yml":      FormatYAMLConfig(string(rules)),
 		},
 	}
 }

--- a/util/uuidutil/uuid.go
+++ b/util/uuidutil/uuid.go
@@ -19,12 +19,13 @@
 package uuidutil
 
 import (
-	"github.com/twinj/uuid"
-	"strings"
+	"crypto/sha256"
+	"encoding/hex"
 )
 
-// NewUUID 创建无-的32位uuid
-func NewUUID() string {
-	uid := uuid.NewV4().String()
-	return strings.Replace(uid, "-", "", -1)
+// NewStableUUID 基于输入字符串生成稳定的32位uuid
+// 相同的输入会生成相同的输出，用于确保同一集群多次安装生成相同的EID
+func NewStableUUID(input string) string {
+	hash := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(hash[:])[:32]
 }


### PR DESCRIPTION
  - Use kube-system namespace UID to generate stable EID, fixing the issue where multiple helm install/uninstall on the same cluster were counted as separate installations
  - Use kube-system namespace UID to generate stable MySQL password to prevent password changes after reinstallation
  - Remove unused NewUUID function, add NewStableUUID function
  - Extract FormatYAMLConfig helper function for YAML tab-to-space conversion