### PR TITLE
feat: add default resource requests and limits for all components    …

### DIFF
--- a/controllers/handler/api.go
+++ b/controllers/handler/api.go
@@ -170,6 +170,7 @@ func (a *api) deployment() client.Object {
 	envs = mergeEnvs(envs, a.component.Spec.Env)
 	volumeMounts = mergeVolumeMounts(volumeMounts, a.component.Spec.VolumeMounts)
 	volumes = mergeVolumes(volumes, a.component.Spec.Volumes)
+	resources := setDefaultResources(a.component.Spec.Resources)
 
 	// prepare probe
 	ds := &appsv1.Deployment{
@@ -213,7 +214,7 @@ func (a *api) deployment() client.Object {
 								SuccessThreshold:    1,
 								FailureThreshold:    6,
 							},
-							Resources: a.component.Spec.Resources,
+							Resources: resources,
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/controllers/handler/apigateway.go
+++ b/controllers/handler/apigateway.go
@@ -201,6 +201,7 @@ func (a *apigateway) deploy() client.Object {
 		},
 	}...)
 	images := strings.Split(a.component.Spec.Image, "@")
+	resources := setDefaultResources(a.component.Spec.Resources)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ApiGatewayName,
@@ -273,6 +274,7 @@ func (a *apigateway) deploy() client.Object {
 							Env:                      envs,
 							TerminationMessagePath:   "/dev/termination-log",
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							Resources:                resources,
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -311,6 +313,7 @@ func (a *apigateway) deploy() client.Object {
 							VolumeMounts:             vms,
 							TerminationMessagePath:   "/dev/termination-log",
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							Resources:                resources,
 						},
 					},
 					Volumes: vs,

--- a/controllers/handler/app-ui.go
+++ b/controllers/handler/app-ui.go
@@ -222,6 +222,7 @@ func (a *appui) deploymentForAppUI() client.Object {
 	envs = mergeEnvs(envs, a.component.Spec.Env)
 	volumeMounts = mergeVolumeMounts(volumeMounts, a.component.Spec.VolumeMounts)
 	volumes = mergeVolumes(volumes, a.component.Spec.Volumes)
+	resources := setDefaultResources(a.component.Spec.Resources)
 
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -263,7 +264,7 @@ func (a *appui) deploymentForAppUI() client.Object {
 								SuccessThreshold:    1,
 								FailureThreshold:    6,
 							},
-							Resources: a.component.Spec.Resources,
+							Resources: resources,
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/controllers/handler/chaos.go
+++ b/controllers/handler/chaos.go
@@ -253,6 +253,7 @@ func (c *chaos) deployment() client.Object {
 	volumeMounts = mergeVolumeMounts(volumeMounts, c.component.Spec.VolumeMounts)
 	volumes = mergeVolumes(volumes, c.component.Spec.Volumes)
 	args = mergeArgs(args, c.component.Spec.Args)
+	resources := setDefaultResources(c.component.Spec.Resources)
 
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -301,7 +302,7 @@ func (c *chaos) deployment() client.Object {
 								SuccessThreshold:    1,
 								FailureThreshold:    6,
 							},
-							Resources: c.component.Spec.Resources,
+							Resources: resources,
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/controllers/handler/common.go
+++ b/controllers/handler/common.go
@@ -25,6 +25,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// DefaultResourceRequestCPU defines the default CPU request for components
+	DefaultResourceRequestCPU = "100m"
+	// DefaultResourceRequestMemory defines the default memory request for components
+	DefaultResourceRequestMemory = "256Mi"
+	// DefaultResourceLimitCPU defines the default CPU limit for components
+	DefaultResourceLimitCPU = "4"
+	// DefaultResourceLimitMemory defines the default memory limit for components
+	DefaultResourceLimitMemory = "8Gi"
+)
+
 // ErrNoDBEndpoints -
 var ErrNoDBEndpoints = errors.New("no ready endpoints for DB were found")
 
@@ -468,4 +479,41 @@ func createIngressMeta(name, namespace string, annotations, labels map[string]st
 // FormatYAMLConfig 将 YAML 配置中的 tab 替换为空格，确保 YAML 格式正确
 func FormatYAMLConfig(config string) string {
 	return strings.ReplaceAll(config, "\t", "  ")
+}
+
+// setDefaultResources sets default resource requests and limits if not specified
+// Returns a ResourceRequirements with default requests of 100m CPU and 256Mi memory,
+// and default limits of 4 CPU cores and 8Gi memory
+func setDefaultResources(resources corev1.ResourceRequirements) corev1.ResourceRequirements {
+	result := resources.DeepCopy()
+
+	// Initialize Requests and Limits maps if nil
+	if result.Requests == nil {
+		result.Requests = make(corev1.ResourceList)
+	}
+	if result.Limits == nil {
+		result.Limits = make(corev1.ResourceList)
+	}
+
+	// Set default CPU request if not specified
+	if _, exists := result.Requests[corev1.ResourceCPU]; !exists {
+		result.Requests[corev1.ResourceCPU] = resource.MustParse(DefaultResourceRequestCPU)
+	}
+
+	// Set default memory request if not specified
+	if _, exists := result.Requests[corev1.ResourceMemory]; !exists {
+		result.Requests[corev1.ResourceMemory] = resource.MustParse(DefaultResourceRequestMemory)
+	}
+
+	// Set default CPU limit if not specified
+	if _, exists := result.Limits[corev1.ResourceCPU]; !exists {
+		result.Limits[corev1.ResourceCPU] = resource.MustParse(DefaultResourceLimitCPU)
+	}
+
+	// Set default memory limit if not specified
+	if _, exists := result.Limits[corev1.ResourceMemory]; !exists {
+		result.Limits[corev1.ResourceMemory] = resource.MustParse(DefaultResourceLimitMemory)
+	}
+
+	return *result
 }

--- a/controllers/handler/db.go
+++ b/controllers/handler/db.go
@@ -221,6 +221,7 @@ func (d *db) statefulsetForDB() client.Object {
 	env = mergeEnvs(env, d.component.Spec.Env)
 	volumeMounts = mergeVolumeMounts(volumeMounts, d.component.Spec.VolumeMounts)
 	volumes = mergeVolumes(volumes, d.component.Spec.Volumes)
+	resources := setDefaultResources(d.component.Spec.Resources)
 
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -261,7 +262,7 @@ func (d *db) statefulsetForDB() client.Object {
 								PeriodSeconds:       2,
 								TimeoutSeconds:      1,
 							},
-							Resources: d.component.Spec.Resources,
+							Resources: resources,
 						},
 					},
 					Volumes: volumes,

--- a/controllers/handler/hub.go
+++ b/controllers/handler/hub.go
@@ -261,6 +261,7 @@ func (h *hub) deployment() client.Object {
 	env = mergeEnvs(env, h.component.Spec.Env)
 	volumeMounts = mergeVolumeMounts(volumeMounts, h.component.Spec.VolumeMounts)
 	volumes = mergeVolumes(volumes, h.component.Spec.Volumes)
+	resources := setDefaultResources(h.component.Spec.Resources)
 
 	ds := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -289,7 +290,7 @@ func (h *hub) deployment() client.Object {
 							ImagePullPolicy: h.component.ImagePullPolicy(),
 							Env:             env,
 							VolumeMounts:    volumeMounts,
-							Resources:       h.component.Spec.Resources,
+							Resources:       resources,
 						},
 					},
 					Volumes: volumes,

--- a/controllers/handler/local_path.go
+++ b/controllers/handler/local_path.go
@@ -144,7 +144,7 @@ func (l *localPath) deployment() client.Object {
 		Name:            "local-path-provisioner",
 		Image:           l.component.Spec.Image,
 		ImagePullPolicy: l.component.ImagePullPolicy(),
-		Resources:       l.component.Spec.Resources,
+		Resources:       setDefaultResources(l.component.Spec.Resources),
 		Command: []string{
 			"local-path-provisioner",
 			"--debug",

--- a/controllers/handler/minio.go
+++ b/controllers/handler/minio.go
@@ -104,7 +104,7 @@ func (m *minIO) statefulSet() client.Object {
 								"minio server /data --console-address :9001",
 							},
 							VolumeMounts: vms,
-							Resources:    m.component.Spec.Resources,
+							Resources:    setDefaultResources(m.component.Spec.Resources),
 							Env: []corev1.EnvVar{
 								{
 									Name:  "MINIO_BUCKETS",

--- a/controllers/handler/monitor.go
+++ b/controllers/handler/monitor.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/goodrain/rainbond-operator/util/constants"
 	"github.com/goodrain/rainbond-operator/util/rbdutil"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	rainbondv1alpha1 "github.com/goodrain/rainbond-operator/api/v1alpha1"
 	"github.com/goodrain/rainbond-operator/util/commonutil"
@@ -77,18 +76,7 @@ func (m *monitor) statefulset() client.Object {
 	claimName := "data" // unnecessary
 	promDataPVC := createPersistentVolumeClaimRWO(m.component.Namespace, claimName, m.pvcParametersRWO, m.labels, m.storageRequest)
 
-	resources := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("2048Mi"),
-			corev1.ResourceCPU:    resource.MustParse("1000m"),
-		},
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-			corev1.ResourceCPU:    resource.MustParse("200m"),
-		},
-	}
-
-	resources = mergeResources(resources, m.component.Spec.Resources)
+	resources := setDefaultResources(m.component.Spec.Resources)
 
 	vms := append(m.component.Spec.VolumeMounts, []corev1.VolumeMount{
 		{

--- a/controllers/handler/mq.go
+++ b/controllers/handler/mq.go
@@ -92,6 +92,7 @@ func (m *mq) deployment() client.Object {
 	args = mergeArgs(args, m.component.Spec.Args)
 	volumeMounts = mergeVolumeMounts(volumeMounts, m.component.Spec.VolumeMounts)
 	volumes = mergeVolumes(volumes, m.component.Spec.Volumes)
+	resources := setDefaultResources(m.component.Spec.Resources)
 
 	ds := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -121,7 +122,7 @@ func (m *mq) deployment() client.Object {
 							Env:             env,
 							Args:            args,
 							VolumeMounts:    volumeMounts,
-							Resources:       m.component.Spec.Resources,
+							Resources:       resources,
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/controllers/handler/worker.go
+++ b/controllers/handler/worker.go
@@ -162,6 +162,7 @@ func (w *worker) deployment() client.Object {
 	env = mergeEnvs(env, w.component.Spec.Env)
 	volumeMounts = mergeVolumeMounts(volumeMounts, w.component.Spec.VolumeMounts)
 	volumes = mergeVolumes(volumes, w.component.Spec.Volumes)
+	resources := setDefaultResources(w.component.Spec.Resources)
 
 	// prepare probe
 	ds := &appsv1.Deployment{
@@ -206,7 +207,7 @@ func (w *worker) deployment() client.Object {
 								SuccessThreshold:    1,
 								FailureThreshold:    6,
 							},
-							Resources: w.component.Spec.Resources,
+							Resources: resources,
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{


### PR DESCRIPTION
…                                                        Set default requests (100m CPU, 256Mi memory) and limits (4 CPU, 8Gi memory)to ensure better pod scheduling while preventing resource exhaustion.