### PR TITLE
feat: support APISIX 3.14 gateway configuration

### DIFF
--- a/controllers/handler/apigateway.go
+++ b/controllers/handler/apigateway.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goodrain/rainbond-operator/util/k8sutil"
 	"github.com/goodrain/rainbond-operator/util/rbdutil"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,7 +25,10 @@ import (
 // ApiGatewayName name for rbd-gateway.
 var ApiGatewayName = "rbd-gateway"
 
-const apiGatewayResourceRequestEphemeralStorage = "512Mi"
+const (
+	apiGatewayResourceRequestEphemeralStorage = "512Mi"
+	apisixAdminKey                            = "edd1c9f034335f136f87ad84b625c8f1"
+)
 
 type apigateway struct {
 	ctx       context.Context
@@ -114,8 +118,19 @@ func (a *apigateway) Resources() []client.Object {
 		Name:      "apisix-gw-config.yaml",
 		Namespace: a.component.Namespace,
 	}, &cm)
-	if err != nil && apierrors.IsNotFound(err) {
-		objs = append(objs, a.configmap())
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			objs = append(objs, a.configmap())
+		} else {
+			logrus.WithError(err).Warn("failed to get APISIX config map")
+		}
+	} else {
+		changed, migrateErr := ensureAPISIXAdminConfig(&cm)
+		if migrateErr != nil {
+			logrus.WithError(migrateErr).Warn("failed to migrate APISIX admin configuration")
+		} else if changed {
+			objs = append(objs, &cm)
+		}
 	}
 	objs = append(objs,
 		a.deploy(),
@@ -123,6 +138,111 @@ func (a *apigateway) Resources() []client.Object {
 		a.monitorService(),
 	)
 	return objs
+}
+
+func ensureAPISIXAdminConfig(configMap *corev1.ConfigMap) (bool, error) {
+	config, ok := configMap.Data["config.yaml"]
+	if !ok {
+		return false, fmt.Errorf("config.yaml not found in ConfigMap %s/%s", configMap.Namespace, configMap.Name)
+	}
+
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(config), &document); err != nil {
+		return false, fmt.Errorf("parse config.yaml: %w", err)
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return false, fmt.Errorf("config.yaml root must be a mapping")
+	}
+
+	root := document.Content[0]
+	deployment, changed := ensureYAMLMapping(root, "deployment")
+	admin, adminChanged := ensureYAMLMapping(deployment, "admin")
+	changed = changed || adminChanged
+	changed = setYAMLScalar(admin, "admin_key_required", "!!bool", "true") || changed
+	changed = setYAMLScalar(admin, "admin_api_version", "!!str", "v3") || changed
+
+	adminKeys, keysChanged := ensureYAMLSequence(admin, "admin_key")
+	changed = changed || keysChanged
+	adminEntry := findYAMLMappingByScalar(adminKeys, "name", "admin")
+	if adminEntry == nil {
+		adminEntry = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		adminKeys.Content = append(adminKeys.Content, adminEntry)
+		changed = true
+	}
+	changed = setYAMLScalar(adminEntry, "name", "!!str", "admin") || changed
+	changed = setYAMLScalar(adminEntry, "key", "!!str", apisixAdminKey) || changed
+	changed = setYAMLScalar(adminEntry, "role", "!!str", "admin") || changed
+
+	if !changed {
+		return false, nil
+	}
+	updated, err := yaml.Marshal(&document)
+	if err != nil {
+		return false, fmt.Errorf("marshal config.yaml: %w", err)
+	}
+	configMap.Data["config.yaml"] = string(updated)
+	return true, nil
+}
+
+func ensureYAMLMapping(parent *yaml.Node, key string) (*yaml.Node, bool) {
+	if existing := yamlMappingValue(parent, key); existing != nil && existing.Kind == yaml.MappingNode {
+		return existing, false
+	}
+	value := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	setYAMLValue(parent, key, value)
+	return value, true
+}
+
+func ensureYAMLSequence(parent *yaml.Node, key string) (*yaml.Node, bool) {
+	if existing := yamlMappingValue(parent, key); existing != nil && existing.Kind == yaml.SequenceNode {
+		return existing, false
+	}
+	value := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	setYAMLValue(parent, key, value)
+	return value, true
+}
+
+func setYAMLScalar(parent *yaml.Node, key, tag, value string) bool {
+	existing := yamlMappingValue(parent, key)
+	if existing != nil && existing.Kind == yaml.ScalarNode && existing.Tag == tag && existing.Value == value {
+		return false
+	}
+	setYAMLValue(parent, key, &yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: value})
+	return true
+}
+
+func setYAMLValue(parent *yaml.Node, key string, value *yaml.Node) {
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value == key {
+			parent.Content[i+1] = value
+			return
+		}
+	}
+	parent.Content = append(parent.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		value,
+	)
+}
+
+func yamlMappingValue(parent *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value == key {
+			return parent.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func findYAMLMappingByScalar(sequence *yaml.Node, key, value string) *yaml.Node {
+	for _, item := range sequence.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		if field := yamlMappingValue(item, key); field != nil && field.Value == value {
+			return item
+		}
+	}
+	return nil
 }
 
 // After -
@@ -273,8 +393,10 @@ func (a *apigateway) deploy() client.Object {
 								"default",
 								"--default-apisix-cluster-base-url",
 								"http://127.0.0.1:9180/apisix/admin",
+								"--apisix-admin-api-version",
+								"v3",
 								"--default-apisix-cluster-admin-key",
-								"edd1c9f034335f136f87ad84b625c8f1",
+								apisixAdminKey,
 								"--api-version",
 								"apisix.apache.org/v2",
 								"--ingress-status-address",
@@ -400,12 +522,6 @@ func (a *apigateway) monitorGlobalRule() client.Object {
 					Config: v2.ApisixRoutePluginConfig{
 						"prefer_name": true,
 					},
-				}, {
-					Name:   "k8s-upstream-metrics",
-					Enable: true,
-					Config: v2.ApisixRoutePluginConfig{
-						"enable_service_id": true,
-					},
 				},
 			},
 		},
@@ -414,7 +530,7 @@ func (a *apigateway) monitorGlobalRule() client.Object {
 
 // configmap 配置文件
 func (a *apigateway) configmap() client.Object {
-	configYaml := `
+	configYaml := fmt.Sprintf(`
 plugin_attr:
   prometheus:
     metrics:
@@ -428,6 +544,12 @@ plugin_attr:
 
 deployment:
   admin:
+    admin_key_required: true
+    admin_key:
+      - name: admin
+        key: %s
+        role: admin
+    admin_api_version: v3
     allow_admin:
       - 127.0.0.0/24
       - 0.0.0.0/0
@@ -545,7 +667,7 @@ plugins: # plugin list (sorted by priority)
   - serverless-post-function       # priority: -2000
   - ext-plugin-post-req            # priority: -3000
   - ext-plugin-post-resp           # priority: -4000
-`
+`, apisixAdminKey)
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "apisix-gw-config.yaml",

--- a/controllers/handler/apigateway_test.go
+++ b/controllers/handler/apigateway_test.go
@@ -2,13 +2,17 @@ package handler
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	rainbondv1alpha1 "github.com/goodrain/rainbond-operator/api/v1alpha1"
+	v2 "github.com/goodrain/rainbond-operator/api/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestAPIGatewayResourcesPreserveConfiguredEphemeralStorageRequest(t *testing.T) {
@@ -33,7 +37,7 @@ func TestAPIGatewayDeploymentIsCriticalAndRunsOncePerGatewayNode(t *testing.T) {
 			Namespace: "rbd-system",
 		},
 		Spec: rainbondv1alpha1.RbdComponentSpec{
-			Image: "example.com/apisix-ingress:test@example.com/apisix:test",
+			Image: "example.com/apisix-ingress:1.8.3@registry.cn-hangzhou.aliyuncs.com/goodrain/apisix:3.14.1-debian",
 		},
 	}
 	cluster := &rainbondv1alpha1.RainbondCluster{
@@ -56,6 +60,27 @@ func TestAPIGatewayDeploymentIsCriticalAndRunsOncePerGatewayNode(t *testing.T) {
 		t.Fatalf("expected *appsv1.Deployment, got %T", handler.deploy())
 	}
 	podSpec := deployment.Spec.Template.Spec
+	var ingressContainer, apisixContainer *corev1.Container
+	for i := range podSpec.Containers {
+		switch podSpec.Containers[i].Name {
+		case "ingress-apisix":
+			ingressContainer = &podSpec.Containers[i]
+		case "apisix":
+			apisixContainer = &podSpec.Containers[i]
+		}
+	}
+	if ingressContainer == nil {
+		t.Fatal("expected ingress-apisix container")
+	}
+	if !strings.Contains(strings.Join(ingressContainer.Command, " "), "--apisix-admin-api-version v3") {
+		t.Fatalf("expected ingress controller to use APISIX Admin API v3, got %v", ingressContainer.Command)
+	}
+	if apisixContainer == nil {
+		t.Fatal("expected apisix container")
+	}
+	if got := apisixContainer.Image; got != "registry.cn-hangzhou.aliyuncs.com/goodrain/apisix:3.14.1-debian" {
+		t.Fatalf("expected APISIX 3.14.1 image, got %q", got)
+	}
 	if got := podSpec.PriorityClassName; got != "system-cluster-critical" {
 		t.Fatalf("expected priority class system-cluster-critical, got %q", got)
 	}
@@ -92,5 +117,112 @@ func TestAPIGatewayDeploymentIsCriticalAndRunsOncePerGatewayNode(t *testing.T) {
 	}
 	if got := terms[0].LabelSelector.MatchLabels["name"]; got != ApiGatewayName {
 		t.Fatalf("expected pod anti-affinity to select %s, got %q", ApiGatewayName, got)
+	}
+}
+
+func TestMonitorGlobalRuleUsesOnlyBuiltInPrometheus(t *testing.T) {
+	t.Parallel()
+
+	rule := (&apigateway{}).monitorGlobalRule().(*v2.ApisixGlobalRule)
+	if len(rule.Spec.Plugins) != 1 {
+		t.Fatalf("expected one global plugin, got %d", len(rule.Spec.Plugins))
+	}
+	if got := rule.Spec.Plugins[0].Name; got != "prometheus" {
+		t.Fatalf("expected prometheus global plugin, got %q", got)
+	}
+}
+
+func TestAPIGatewayConfigUsesSameAdminKeyAndAPIVersionAsIngressController(t *testing.T) {
+	t.Parallel()
+
+	configMap := (&apigateway{}).configmap().(*corev1.ConfigMap)
+	config := configMap.Data["config.yaml"]
+	for _, expected := range []string{
+		"admin_key_required: true",
+		"admin_key:",
+		"name: admin",
+		"key: " + apisixAdminKey,
+		"role: admin",
+		"admin_api_version: v3",
+	} {
+		if !strings.Contains(config, expected) {
+			t.Fatalf("expected APISIX config to contain %q, got:\n%s", expected, config)
+		}
+	}
+}
+
+func TestAPIGatewayResourcesMigratesAdminConfigWithoutReplacingCustomSettings(t *testing.T) {
+	t.Parallel()
+
+	component := &rainbondv1alpha1.RbdComponent{
+		ObjectMeta: metav1.ObjectMeta{Name: ApiGatewayName, Namespace: "rbd-system"},
+	}
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "apisix-gw-config.yaml", Namespace: component.Namespace},
+		Data: map[string]string{
+			"config.yaml": `deployment:
+  admin:
+    allow_admin:
+      - 10.0.0.0/8
+    admin_key:
+      - name: viewer
+        key: read-only
+        role: viewer
+      - name: admin
+        key: outdated
+        role: viewer
+  etcd:
+    host:
+      - http://127.0.0.1:12379
+custom_setting:
+  preserved: true
+`,
+		},
+	}
+	k8sClient := &staticClient{
+		scheme: runtime.NewScheme(),
+		objects: map[client.ObjectKey]client.Object{
+			{Name: existing.Name, Namespace: existing.Namespace}: existing,
+		},
+	}
+	handler := &apigateway{
+		ctx:       context.Background(),
+		client:    k8sClient,
+		component: component,
+		cluster:   &rainbondv1alpha1.RainbondCluster{},
+		labels:    LabelsForRainbondComponent(component),
+	}
+
+	var migrated *corev1.ConfigMap
+	for _, object := range handler.Resources() {
+		if configMap, ok := object.(*corev1.ConfigMap); ok && configMap.Name == existing.Name {
+			migrated = configMap
+			break
+		}
+	}
+	if migrated == nil {
+		t.Fatal("expected existing APISIX ConfigMap to be migrated")
+	}
+	config := migrated.Data["config.yaml"]
+	for _, expected := range []string{
+		"admin_key_required: true",
+		"admin_api_version: v3",
+		"key: " + apisixAdminKey,
+		"key: read-only",
+		"role: viewer",
+		"10.0.0.0/8",
+		"custom_setting:",
+		"preserved: true",
+	} {
+		if !strings.Contains(config, expected) {
+			t.Fatalf("expected migrated APISIX config to contain %q, got:\n%s", expected, config)
+		}
+	}
+	changed, err := ensureAPISIXAdminConfig(migrated)
+	if err != nil {
+		t.Fatalf("expected migrated APISIX config to remain valid: %v", err)
+	}
+	if changed {
+		t.Fatal("expected APISIX admin config migration to be idempotent")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.20.6
 	k8s.io/apimachinery v0.20.6
 	k8s.io/client-go v0.20.6
@@ -85,7 +86,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.19.2 // indirect
 	k8s.io/component-base v0.20.6 // indirect
 	k8s.io/klog/v2 v2.4.0 // indirect


### PR DESCRIPTION
## Summary

- configure APISIX Admin API v3 for APISIX Ingress Controller 1.8.4
- keep the APISIX Admin credential consistent between APISIX and the ingress controller
- migrate existing APISIX ConfigMaps without replacing manual gateway settings
- remove the unavailable k8s-upstream-metrics plugin and retain built-in Prometheus metrics
- verify propagation of the APISIX Ingress Controller 1.8.4 and APISIX 3.14.1 images
- add regression coverage for deployment arguments, plugins, and ConfigMap migration

## Related

- goodrain/rainbond-chart#135

## Verification

- `/Users/zhangqi/.gvm/gos/go1.24/bin/go test -mod=mod ./...`
- `/Users/zhangqi/.gvm/gos/go1.24/bin/go vet -mod=mod ./...`
- `/Users/zhangqi/.gvm/gos/go1.24/bin/go build -mod=mod ./...`
- `git diff --check`