### PR TITLE
test: verify APISIX ingress controller 1.8.4

### DIFF
--- a/controllers/handler/apigateway_test.go
+++ b/controllers/handler/apigateway_test.go
@@ -37,7 +37,7 @@ func TestAPIGatewayDeploymentIsCriticalAndRunsOncePerGatewayNode(t *testing.T) {
 			Namespace: "rbd-system",
 		},
 		Spec: rainbondv1alpha1.RbdComponentSpec{
-			Image: "example.com/apisix-ingress:1.8.3@registry.cn-hangzhou.aliyuncs.com/goodrain/apisix:3.14.1-debian",
+			Image: "example.com/apisix-ingress:1.8.4@registry.cn-hangzhou.aliyuncs.com/goodrain/apisix:3.14.1-debian",
 		},
 	}
 	cluster := &rainbondv1alpha1.RainbondCluster{
@@ -71,6 +71,9 @@ func TestAPIGatewayDeploymentIsCriticalAndRunsOncePerGatewayNode(t *testing.T) {
 	}
 	if ingressContainer == nil {
 		t.Fatal("expected ingress-apisix container")
+	}
+	if got := ingressContainer.Image; got != "example.com/apisix-ingress:1.8.4" {
+		t.Fatalf("expected APISIX ingress controller 1.8.4 image, got %q", got)
 	}
 	if !strings.Contains(strings.Join(ingressContainer.Command, " "), "--apisix-admin-api-version v3") {
 		t.Fatalf("expected ingress controller to use APISIX Admin API v3, got %v", ingressContainer.Command)


### PR DESCRIPTION
## Summary
- update the API gateway deployment fixture to APISIX Ingress Controller 1.8.4
- verify that the operator extracts the 1.8.4 controller image from the combined RbdComponent image
- keep APISIX Admin API v3 and APISIX 3.14.1 coverage

## Verification
- go test -mod=mod ./...
- go vet -mod=mod ./...
- go build -mod=mod ./...

The runtime controller tag is supplied by rainbond-chart; this PR guards the operator image-splitting behavior for the new tag.